### PR TITLE
Implement TTL for Cache Entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 # Copy package files
 COPY package.json bun.lockb* ./
 
+# Install python3 and build tools for native modules (hnswlib-node)
+RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies
 RUN bun install
 

--- a/src/lib/semantic-cache.js
+++ b/src/lib/semantic-cache.js
@@ -13,6 +13,7 @@ class SemanticCache {
     this.maxElements = options.maxElements || 100000;
     this.similarityThreshold = options.similarityThreshold || 0.85;
     this.memoryLimit = options.memoryLimit || '1gb';
+    this.defaultTTL = options.defaultTTL || 3600; // Default TTL: 1 hour (seconds)
     
     // Initialize components
     this.index = new HNSWIndex(this.dim, this.maxElements, 'cosine');
@@ -98,8 +99,9 @@ class SemanticCache {
    * @param {string} prompt - Original prompt
    * @param {string} response - LLM response
    * @param {number[]} embedding - Vector embedding
+   * @param {object} options - Cache options (e.g., ttl)
    */
-  async set(prompt, response, embedding) {
+  async set(prompt, response, embedding, options = {}) {
     // Normalize and hash prompt
     const normalized = this.normalizer.normalize(prompt);
     const promptHash = this.normalizer.hash(prompt);
@@ -132,7 +134,8 @@ class SemanticCache {
       accessCount: 0
     };
     
-    this.metadataStore.set(id, metadata);
+    const ttl = options.ttl || this.defaultTTL;
+    this.metadataStore.set(id, metadata, ttl);
   }
 
   /**

--- a/tests/ttl.test.js
+++ b/tests/ttl.test.js
@@ -1,0 +1,81 @@
+const SemanticCache = require('../src/lib/semantic-cache');
+
+describe('TTL Functionality', () => {
+  let cache;
+  const dim = 128;
+
+  beforeEach(() => {
+    cache = new SemanticCache({
+      dim,
+      maxElements: 1000,
+      similarityThreshold: 0.85,
+      defaultTTL: 1 // 1 second default
+    });
+  });
+
+  afterEach(() => {
+    cache.destroy();
+  });
+
+  test('should expire exact match after TTL', async () => {
+    const prompt = 'Exact match expiry test';
+    const response = 'Response';
+    const embedding = Array(dim).fill(0).map(() => Math.random());
+    const ttl = 0.5; // 0.5 seconds
+
+    await cache.set(prompt, response, embedding, { ttl });
+
+    // Immediate check
+    const immediate = await cache.get(prompt);
+    expect(immediate).not.toBeNull();
+    expect(immediate.response).toBe(response);
+
+    // Wait for expiration
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    // Check after expiry
+    const expired = await cache.get(prompt);
+    expect(expired).toBeNull(); // Should return null because it's expired
+  });
+
+  test('should expire semantic match after TTL', async () => {
+    const prompt = 'Semantic match expiry test';
+    const response = 'Response';
+    const embedding = Array(dim).fill(0).map(() => Math.random());
+    const ttl = 0.5; // 0.5 seconds
+
+    await cache.set(prompt, response, embedding, { ttl });
+
+    // Immediate check with semantic search
+    const immediate = await cache.get(prompt, embedding);
+    expect(immediate).not.toBeNull();
+    expect(immediate.response).toBe(response);
+
+    // Wait for expiration
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    // Check after expiry
+    const expired = await cache.get(prompt, embedding);
+    expect(expired).toBeNull(); // Should return null because it's expired
+  });
+
+  test('should use default TTL if not specified', async () => {
+    const prompt = 'Default TTL test';
+    const response = 'Response';
+    const embedding = Array(dim).fill(0).map(() => Math.random());
+
+    // Default TTL is 1 second (set in beforeEach)
+    await cache.set(prompt, response, embedding);
+
+    // Immediate check
+    const immediate = await cache.get(prompt);
+    expect(immediate).not.toBeNull();
+
+    // Wait for expiration
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    // Check after expiry
+    const expired = await cache.get(prompt);
+    expect(expired).toBeNull();
+  });
+});


### PR DESCRIPTION
Implemented Time-To-Live (TTL) functionality for the Semantic Cache.

Changes:
- Modified `src/lib/metadata-store.js`:
  - `set` now accepts a `ttl` (in seconds) and calculates `expiresAt`.
  - `get` and `findByPromptHash` check `expiresAt`. If expired, the entry is deleted and `undefined` is returned.
- Modified `src/lib/semantic-cache.js`:
  - Constructor accepts `defaultTTL` (default 3600s).
  - `set` accepts `options.ttl` (defaulting to `defaultTTL`) and passes it to the metadata store.
- Added `tests/ttl.test.js` to verify exact match and semantic search expiry.

This implements "lazy expiration" where expired items are removed only when accessed.

---
*PR created automatically by Jules for task [2333544077903741745](https://jules.google.com/task/2333544077903741745) started by @EricNguyen1206*