### PR TITLE
🧹 remove unused getCompressionRatio method

### DIFF
--- a/src/lib/compressor.js
+++ b/src/lib/compressor.js
@@ -39,18 +39,6 @@ class Compressor {
     const decompressed = lz4js.decompress(data);
     return Buffer.from(decompressed).toString('utf8');
   }
-
-  /**
-   * Calculate compression ratio
-   * @param {string} original - Original data
-   * @param {Buffer} compressed - Compressed data
-   * @returns {number} Ratio (0-1)
-   */
-  getCompressionRatio(original, compressed) {
-    const originalSize = Buffer.byteLength(original, 'utf8');
-    if (originalSize === 0) return 0;
-    return compressed.length / originalSize;
-  }
 }
 
 export default Compressor;

--- a/tests/compressor.test.js
+++ b/tests/compressor.test.js
@@ -16,15 +16,6 @@ describe('Compressor', () => {
     expect(decompressed).toBe(original);
   });
 
-  test('should calculate compression ratio', () => {
-    const text = 'A'.repeat(1000);
-    const compressed = compressor.compress(text);
-    const ratio = compressor.getCompressionRatio(text, compressed);
-    
-    expect(ratio).toBeGreaterThan(0);
-    expect(ratio).toBeLessThan(1);
-  });
-
   test('should handle empty string', () => {
     const compressed = compressor.compress('');
     const decompressed = compressor.decompress(compressed, 0);


### PR DESCRIPTION
The `getCompressionRatio` method in `src/lib/compressor.js` was identified as dead code since it was only referenced in its own unit test. This PR removes the method and its associated test to simplify the codebase and improve maintainability.

🎯 **What:** Removed unused `getCompressionRatio` method.
💡 **Why:** Improved maintainability by removing dead code.
✅ **Verification:** Verified with `grep` that no other references exist. Ran remaining tests in `tests/compressor.test.js` (using a mock for the missing `lz4js` dependency) to ensure no regressions.
✨ **Result:** Cleaner and more maintainable `Compressor` class.

---
*PR created automatically by Jules for task [16626261107841221922](https://jules.google.com/task/16626261107841221922) started by @EricNguyen1206*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Removed compression ratio calculation method from the Compressor class and associated test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->