### PR TITLE
feat: prepare release 1 self-hosted integration surface

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,33 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.4'
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Run race tests
+        run: go test -race ./...
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+
   build-and-push:
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,7 +55,6 @@ jobs:
 
       - name: Build Binary
         run: |
-          go mod tidy
           go build -ldflags="-s -w" -o erion-ember ./cmd/server/
 
       - name: Log in to the Container registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,31 @@
-# Build stage — pure Go, CGO_ENABLED=0, smallest possible binary
+# Build stage - pure Go, CGO_ENABLED=0, smallest possible binary
 FROM golang:1.23-alpine AS builder
 
 ENV CGO_ENABLED=0
 
 WORKDIR /app
-COPY . .
-RUN go mod tidy && \
-    go build -ldflags="-s -w" -o /bin/erion-ember ./cmd/server/
+COPY go.mod go.sum ./
+RUN go mod download
 
-# Runtime stage — minimal scratch-like image
+COPY . .
+RUN go build -ldflags="-s -w" -o /bin/erion-ember ./cmd/server/
+
+# Runtime stage - minimal Alpine image with non-root user
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && \
+    addgroup -S ember && \
+    adduser -S -G ember -h /app ember
+
+ENV HTTP_PORT=8080 \
+    GRPC_PORT=9090 \
+    CACHE_SIMILARITY_THRESHOLD=0.85 \
+    CACHE_MAX_ELEMENTS=100000 \
+    CACHE_DEFAULT_TTL=3600
+
+WORKDIR /app
 
 COPY --from=builder /bin/erion-ember /bin/erion-ember
 
 EXPOSE 8080 9090
+USER ember:ember
 ENTRYPOINT ["/bin/erion-ember"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean run lint test-verbose test-race
+.PHONY: build test clean run lint test-verbose test-race docker-build release-validate
 
 BIN := bin/erion-ember
 
@@ -29,5 +29,12 @@ clean:
 ## lint: run golangci-lint
 lint:
 	golangci-lint run ./...
+
+## docker-build: build the container image locally
+docker-build:
+	docker build -t erion-ember:local .
+
+## release-validate: run release validation checklist
+release-validate: build test test-race lint
 
 .DEFAULT_GOAL := build

--- a/README.md
+++ b/README.md
@@ -2,16 +2,24 @@
 
 ![Erion Ember Logo](assets/logo-horizontal.svg)
 
-High-performance semantic cache service for LLM applications. Deployable as a standalone binary - like Redis, but for LLM responses. Erion Ember acts as a persistent, radiant "ember" for your intelligence layer, providing micro-second speed and semantic awareness.
+High-performance semantic cache service for chat backends. Release 1 is a self-hosted, single-node, memory-only cache that checks exact matches first and then falls back to lexical similarity with BM25 + Jaccard.
+
+## Release 1 Docs
+
+- [User Guide](docs/USER_GUIDE.md) - quickstart, operating model, and rollout advice.
+- [API Reference](docs/API_REFERENCE.md) - gRPC and HTTP request/response details.
+- [Architecture](docs/ARCHITECTURE.md) - internal structure and request flow.
+- [Showcase Demo](examples/showcase/README.md) - guided miss -> hit release demo.
 
 ## Features
 
-- **Fast & Slow Path Caching**: Sub-microsecond exact matching via `xxhash` and intelligent similarity detection via BM25 + Jaccard.
+- **Exact-First Retrieval**: Fast `xxhash` lookup before lexical similarity fallback with BM25 + Jaccard.
 - **Zero Dependencies**: No model files, no vector databases, no CGO, and no Python required.
-- **Efficient Storage**: Transparent LZ4 compression of all cached data.
+- **Memory-Only Runtime**: Single-node in-memory storage with TTL and LRU eviction.
+- **Efficient Storage**: Transparent LZ4 compression of cached payloads in memory.
 - **Thread-Safe**: Built in Go with high-concurrency memory management.
-- **Dual Protocols**: Native HTTP/JSON and gRPC servers backed by the same cache engine.
-- **No Bundled SDKs**: The repository only ships the core server implementation and handlers.
+- **Dual Protocols**: gRPC is the preferred integration path; HTTP/JSON remains supported.
+- **No Bundled SDKs**: Release 1 ships the core server and protocol surfaces only.
 
 ## Installation
 
@@ -24,45 +32,91 @@ make build
 
 ### Using Docker
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
+
+The published container image runs as a non-root user and exposes the same default ports and cache settings as the source build.
 
 ## Quick Start
 
-1. **Start the server:**
+1. **Build and start the server:**
    ```bash
+   make build
    ./bin/erion-ember
    ```
 
-2. **Cache a response:**
+2. **Confirm the HTTP service is live and ready:**
+   ```bash
+   curl http://localhost:8080/ready
+   curl http://localhost:8080/health
+   ```
+
+3. **Cache a response over HTTP:**
    ```bash
    curl -XPOST http://localhost:8080/v1/cache/set \
+     -H 'Content-Type: application/json' \
      -d '{"prompt": "What is Go?", "response": "Go is a compiled language.", "ttl": 3600}'
    ```
 
-3. **Retrieve with semantic similarity:**
+4. **Retrieve with exact-match confirmation:**
    ```bash
    curl -XPOST http://localhost:8080/v1/cache/get \
-     -d '{"prompt": "Tell me about Go", "similarity_threshold": 0.8}'
+     -H 'Content-Type: application/json' \
+     -d '{"prompt": "What is Go?", "similarity_threshold": 0.8}'
    ```
+
+For backend integrations, prefer gRPC and the public proto at `proto/ember/v1/semantic_cache.proto`.
 
 ## Usage
 
-Erion Ember acts as a middleware for your LLM calls. Check the cache first; if it's a miss, call your LLM and then set the cache.
+Erion Ember sits in front of your chat backend. Check the cache first; on a miss, call your LLM and then store the prompt/response pair.
+
+For release 1, prefer gRPC for backend-to-backend integration. HTTP stays available for local testing, simple deployments, and environments where JSON is easier to wire up.
+
+Current semantic behavior is intentionally simple and explicit: exact prompt match first, then lexical similarity scoring with BM25 + Jaccard when the prompt text overlaps enough to clear the threshold.
 
 See the [User Guide](docs/USER_GUIDE.md) for detailed workflows.
+If you want copy-pasteable raw integrations without an SDK, start with `examples/go/raw-grpc-chat/main.go`, `examples/go/raw-http-chat/main.go`, `examples/node/raw-grpc-chat/index.js`, or `examples/node/raw-http-chat/index.js`.
+For a release-demo sandbox that shows miss -> hit plus changing stats and metrics, run `./examples/showcase/scripts/run-demo.sh` and see `examples/showcase/README.md`.
 
 ## API Reference
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/v1/cache/get` | POST | Retrieve a cached response (semantic search) |
+| `/v1/cache/get` | POST | Retrieve a cached response over HTTP (exact match first, then lexical fallback) |
 | `/v1/cache/set` | POST | Store a prompt/response pair |
 | `/v1/cache/delete` | POST | Remove an entry |
 | `/v1/stats` | GET | View hit rates and cache statistics |
+| `/metrics` | GET | Prometheus-style request and cache metrics |
 | `/health` | GET | Health check |
+| `/ready` | GET | Readiness check |
+
+Preferred gRPC service: `ember.v1.SemanticCacheService` with `Get`, `Set`, `Delete`, `Stats`, and `Health` methods.
 
 Detailed documentation: [API Reference](docs/API_REFERENCE.md)
+
+## Production Limits
+
+Release 1 is intentionally narrow:
+
+- Self-hosted only.
+- Single node only.
+- Memory-only storage with no persistence across restarts.
+- gRPC is the preferred application integration path; HTTP stays available for compatibility and manual testing.
+- HTTP JSON request bodies are capped at 8 MiB; use gRPC when your prompts or responses may exceed that.
+- Best fit is backend-side caching for chat prompts and responses, not long-term storage or multi-node coordination.
+
+Use `CACHE_MAX_ELEMENTS` and `CACHE_DEFAULT_TTL` to keep memory growth within the limits of your host.
+
+## Integration Examples
+
+- Go gRPC: `go run ./examples/go/raw-grpc-chat`
+- Go HTTP: `go run ./examples/go/raw-http-chat`
+- Node gRPC: `cd examples/node/raw-grpc-chat && npm install && npm start` (`Node >= 18`)
+- Node HTTP: `cd examples/node/raw-http-chat && npm install && npm start` (`Node >= 18`)
+- Public proto: `proto/ember/v1/semantic_cache.proto`
+
+For a visual release walkthrough, see the showcase demo in `examples/showcase/README.md`.
 
 ## Configuration
 
@@ -75,6 +129,31 @@ Settings can be tuned via `.env` or environment variables:
 | `CACHE_SIMILARITY_THRESHOLD` | `0.85` | Default similarity threshold (0.0–1.0) |
 | `CACHE_MAX_ELEMENTS` | `100000` | LRU capacity limit |
 | `CACHE_DEFAULT_TTL` | `3600` | Default record TTL (seconds) |
+
+Operators can scrape `GET /metrics` to observe request counts, request latency, current cache size, and cache hit/miss totals.
+
+## Release Validation
+
+Run the release checklist locally before cutting a tag or relying on the Docker publish workflow:
+
+```bash
+make release-validate
+make docker-build
+```
+
+Equivalent commands:
+
+```bash
+go build -o bin/erion-ember ./cmd/server/
+go test ./...
+go test -race ./...
+golangci-lint run ./...
+docker build -t erion-ember:local .
+```
+
+The published container image also runs as a non-root user by default for safer self-hosted deployment.
+
+For a near-one-command release demo, run `./examples/showcase/scripts/run-demo.sh`.
 
 ## Troubleshooting
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,7 @@ func run() error {
 		"version", "3.0.0",
 		"http_addr", httpAddr,
 		"grpc_addr", grpcAddr,
+		"http_metrics_path", "/metrics",
 		"similarity_threshold", cfg.SimilarityThreshold,
 		"max_elements", cfg.MaxElements,
 		"engine", "bm25-jaccard",
@@ -93,6 +94,15 @@ func run() error {
 	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
 		shutdownErr = fmt.Errorf("shutdown http server: %w", err)
 	}
+
+	stats := sc.Stats()
+	slog.Info("cache stats",
+		"total_entries", stats.TotalEntries,
+		"cache_hits", stats.CacheHits,
+		"cache_misses", stats.CacheMisses,
+		"total_queries", stats.TotalQueries,
+		"hit_rate", stats.HitRate,
+	)
 
 	return errors.Join(serveErr, shutdownErr)
 }

--- a/cmd/server/public_proto_integration_test.go
+++ b/cmd/server/public_proto_integration_test.go
@@ -1,0 +1,131 @@
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	emberv1 "github.com/EricNguyen1206/erion-ember/proto/ember/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestPublicProtoClientAgainstRunningServer(t *testing.T) {
+	t.Parallel()
+
+	httpPort := freePort(t)
+	grpcPort := freePort(t)
+	serverDir := filepath.Join(repoRoot(t), "cmd", "server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", ".")
+	cmd.Dir = serverDir
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("HTTP_PORT=%s", httpPort),
+		fmt.Sprintf("GRPC_PORT=%s", grpcPort),
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_, _ = cmd.Process.Wait()
+	}()
+
+	waitForReady(t, "http://127.0.0.1:"+httpPort+"/ready")
+
+	conn, err := grpc.NewClient(
+		"127.0.0.1:"+grpcPort,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial gRPC server: %v", err)
+	}
+	defer conn.Close()
+
+	client := emberv1.NewSemanticCacheServiceClient(conn)
+	grpcCtx, grpcCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer grpcCancel()
+
+	setResp, err := client.Set(grpcCtx, &emberv1.SetRequest{
+		Prompt:   "What is Go?",
+		Response: "Go is a compiled language.",
+	})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	if setResp.GetId() == "" {
+		t.Fatal("expected non-empty cache id")
+	}
+
+	getResp, err := client.Get(grpcCtx, &emberv1.GetRequest{Prompt: "What is Go?"})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if !getResp.GetHit() || !getResp.GetExactMatch() {
+		t.Fatalf("expected exact hit, got hit=%t exact=%t", getResp.GetHit(), getResp.GetExactMatch())
+	}
+
+	healthResp, err := client.Health(grpcCtx, &emberv1.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health failed: %v", err)
+	}
+	if healthResp.GetStatus() != "ready" {
+		t.Fatalf("got health status %q, want %q", healthResp.GetStatus(), "ready")
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	return filepath.Dir(filepath.Dir(wd))
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	defer listener.Close()
+
+	return fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+}
+
+func waitForReady(t *testing.T, readyURL string) {
+	t.Helper()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(readyURL)
+		if err == nil {
+			var body struct {
+				Status string `json:"status"`
+			}
+			decodeErr := json.NewDecoder(resp.Body).Decode(&body)
+			_ = resp.Body.Close()
+			if decodeErr == nil && resp.StatusCode == http.StatusOK && body.Status == "ready" {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("server did not become ready at %s", readyURL)
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,18 +2,58 @@
 
 ![Erion Ember Logo](../assets/logo-horizontal.svg)
 
-The Erion Ember API follows simple REST/JSON patterns. All requests and responses use the `application/json` content type.
+Release 1 exposes the same self-hosted, single-node, memory-only semantic cache for chat backends over gRPC and HTTP. Prefer gRPC for backend integration; use HTTP when JSON is the simpler fit for your environment. The cache checks exact prompt matches first and then falls back to lexical similarity scoring with BM25 + Jaccard.
+
+## Quickstart Links
+
+- Public proto: `proto/ember/v1/semantic_cache.proto`
+- Go raw examples: `examples/go/raw-grpc-chat/main.go` and `examples/go/raw-http-chat/main.go`
+- Node raw examples: `examples/node/raw-grpc-chat/index.js` and `examples/node/raw-http-chat/index.js`
+- Showcase demo: `examples/showcase/README.md`
+- Production scope: self-hosted, single-node, memory-only
+
+## Preferred gRPC API
+
+Proto definition: `proto/ember/v1/semantic_cache.proto`
+
+Service: `ember.v1.SemanticCacheService`
+
+| RPC | Request | Response | Notes |
+|-----|---------|----------|-------|
+| `Get` | `GetRequest` | `GetResponse` | Exact match first, then lexical fallback if needed. |
+| `Set` | `SetRequest` | `SetResponse` | Stores a prompt/response pair in memory. |
+| `Delete` | `DeleteRequest` | `DeleteResponse` | Removes an entry by prompt. |
+| `Stats` | `StatsRequest` | `StatsResponse` | Returns cache counters and hit rate. |
+| `Health` | `HealthRequest` | `HealthResponse` | Returns readiness status for the gRPC service. |
+
+Release 1 does not include SDKs. Use the raw Go and Node examples in `examples/` as copy-pasteable integration starting points.
+
+### Example Response
+
+```json
+{
+  "status": "ready"
+}
+```
+
+## HTTP API
+
+HTTP request bodies use `application/json`. Most HTTP responses also use `application/json`, except `GET /metrics`, which returns Prometheus-style text with `text/plain; version=0.0.4`.
+
+Release 1 keeps HTTP for compatibility and debugging, but gRPC is the preferred transport for backend-to-backend use.
+
+HTTP JSON request bodies are capped at 8 MiB. Larger backend payloads should use gRPC instead of HTTP.
 
 ## `POST /v1/cache/get`
 
-Retrieve a response from the cache using semantic similarity.
+Retrieve a response from the cache. The server attempts an exact prompt match first and only runs the lexical fallback when needed.
 
 ### Parameters
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `prompt` | string | Yes | The query string to look up. |
-| `similarity_threshold` | float | No | Override global similarity threshold (0.0–1.0). |
+| `similarity_threshold` | float | No | Override global similarity threshold (0.0–1.0) for lexical fallback. |
 
 ### Example Request
 
@@ -23,14 +63,14 @@ curl -XPOST http://localhost:8080/v1/cache/get \
   -d '{"prompt": "What is Go?", "similarity_threshold": 0.85}'
 ```
 
-### Example Success Response (Hit)
+### Example Success Response (Exact Hit)
 
 ```json
 {
   "hit": true,
   "response": "Go is a compiled, statically typed language.",
-  "similarity": 0.97,
-  "exact_match": false
+  "similarity": 1,
+  "exact_match": true
 }
 ```
 
@@ -38,7 +78,9 @@ curl -XPOST http://localhost:8080/v1/cache/get \
 
 ```json
 {
-  "hit": false
+  "hit": false,
+  "similarity": 0,
+  "exact_match": false
 }
 ```
 
@@ -47,6 +89,7 @@ curl -XPOST http://localhost:8080/v1/cache/get \
 | Code | Description | Solution |
 |------|-------------|----------|
 | `400` | Bad Request | Ensure `prompt` is provided in the JSON body. |
+| `413` | Request Entity Too Large | Keep HTTP JSON payloads under 8 MiB or switch to gRPC. |
 | `405` | Method Not Allowed | Ensure you are using `POST`. |
 
 ---
@@ -79,6 +122,8 @@ curl -XPOST http://localhost:8080/v1/cache/set \
 }
 ```
 
+If `ttl` is omitted or set to `0`, the server uses `CACHE_DEFAULT_TTL`.
+
 ---
 
 ## `POST /v1/cache/delete`
@@ -95,7 +140,16 @@ Remove an entry from the cache by its original prompt.
 
 ```bash
 curl -XPOST http://localhost:8080/v1/cache/delete \
+  -H 'Content-Type: application/json' \
   -d '{"prompt": "What is Go?"}'
+```
+
+### Example Response
+
+```json
+{
+  "deleted": true
+}
 ```
 
 ---
@@ -122,10 +176,42 @@ Get current cache performance statistics.
 
 Basic health check for the service.
 
+This reports process health only. Release 1 has no persistence layer or cluster membership to verify.
+
 ### Example Response
 
 ```json
 {
   "status": "ok"
 }
+```
+
+---
+
+## `GET /ready`
+
+Readiness check for the in-memory service.
+
+### Example Response
+
+```json
+{
+  "status": "ready"
+}
+```
+
+---
+
+## `GET /metrics`
+
+Prometheus-style metrics for HTTP traffic and cache behavior.
+
+### Example Output
+
+```text
+erion_ember_cache_entries 1
+erion_ember_cache_hits_total 1
+erion_ember_cache_misses_total 1
+erion_ember_cache_queries_total 2
+erion_ember_cache_hit_rate 0.5
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2,16 +2,25 @@
 
 ![Erion Ember Logo](../assets/logo-horizontal.svg)
 
-Welcome to Erion Ember! This guide will help you set up and master semantic caching for your LLM applications. Erion Ember is designed to provide high-performance caching that acts like a persistent, radiant "ember" for your intelligence layer.
+Welcome to Erion Ember. Release 1 is a self-hosted, single-node, memory-only semantic cache for chat backends.
 
 ## What is Erion Ember?
 
-Erion Ember is a lightning-fast semantic cache. Unlike traditional caches that require an exact string match, Erion Ember understands when two prompts have the same meaning, even if they use different words.
+Erion Ember is a fast cache for prompt/response pairs. It tries an exact prompt match first, then falls back to lexical similarity scoring with BM25 + Jaccard when prompts share enough overlapping terms.
 
 ### Why Use It?
 - **Save Costs**: Reuse LLM responses for similar queries.
 - **Reduce Latency**: Cached hits return in milliseconds.
-- **Privacy**: High-performance local caching with no cloud dependencies.
+- **Simple Deployment**: Run one in-memory node with no external model or vector service.
+
+## Release 1 Scope
+
+- Self-hosted, single-node, memory-only deployment.
+- gRPC is the preferred integration path for application backends.
+- HTTP remains supported for simple integrations, testing, and debugging.
+- No persistence, clustering, embeddings, or bundled SDKs in release 1.
+- Raw examples live in `examples/go/raw-grpc-chat/main.go`, `examples/go/raw-http-chat/main.go`, `examples/node/raw-grpc-chat/index.js`, and `examples/node/raw-http-chat/index.js`. The Node gRPC example keeps things raw with `@grpc/grpc-js` plus `@grpc/proto-loader` against `proto/ember/v1/semantic_cache.proto`, and the Node examples assume `Node >= 18`.
+- The guided release demo lives in `examples/showcase/README.md` and `examples/showcase/scripts/run-demo.sh`.
 
 ## Getting Started
 
@@ -27,27 +36,42 @@ Run the binary to start the server on port 8080:
 ./bin/erion-ember
 ```
 
+The server also starts the gRPC endpoint on port 9090 by default.
+
+Quick HTTP smoke checks:
+
+```bash
+curl http://localhost:8080/ready
+curl http://localhost:8080/health
+```
+
+If you want an end-to-end backend example instead of `curl`, run `go run ./examples/go/raw-grpc-chat`, `go run ./examples/go/raw-http-chat`, or use `npm install && npm start` in `examples/node/raw-grpc-chat` or `examples/node/raw-http-chat`.
+
+If you want a release-demo walkthrough with stats and metrics, run `./examples/showcase/scripts/run-demo.sh`.
+
 ### 3. Your First Cache Hit
-Try setting a value and then retrieving it with a different but similar prompt.
+Use HTTP for a quick manual check. For production backend integration, prefer gRPC.
 
 **Step 1: Set a response**
 ```bash
 curl -XPOST http://localhost:8080/v1/cache/set \
+  -H 'Content-Type: application/json' \
   -d '{"prompt": "How do I bake a cake?", "response": "Preheat oven to 350..."}'
 ```
 
-**Step 2: Get via similarity**
+**Step 2: Get the cached response**
 ```bash
 curl -XPOST http://localhost:8080/v1/cache/get \
-  -d '{"prompt": "Tell me the steps to bake a cake", "similarity_threshold": 0.8}'
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "How do I bake a cake?", "similarity_threshold": 0.8}'
 ```
-- **Expected Result**: You should see `hit: true` with the original cake instructions.
+- **Expected Result**: You should see `hit: true` immediately because the prompt matches exactly.
 
 ---
 
 ## Mastering Similarity Thresholds
 
-The `similarity_threshold` (0.0 to 1.0) controls how strict the matching is.
+The `similarity_threshold` (0.0 to 1.0) controls how strict the lexical fallback is. Exact matches do not depend on this value.
 
 | Threshold | Strictness | Use Case |
 |-----------|------------|----------|
@@ -59,9 +83,30 @@ The `similarity_threshold` (0.0 to 1.0) controls how strict the matching is.
 
 ## Performance Tips
 
-- **Pre-warming**: Loading common prompts during startup can significantly improve initial performance.
+- **Prompt Shape Matters**: Lexical fallback works best when related prompts still share important words.
+- **Pre-warming**: Loading common prompts during startup can improve early hit rates.
 - **TTL Usage**: Use Short TTLs (e.g., 300s) for rapidly changing data, and long TTLs for static information like FAQs.
-- **Compression**: Erion Ember uses LZ4 compression automatically. You don't need to pre-compress your JSON payloads.
+- **Compression**: Erion Ember uses LZ4 compression automatically. You do not need to pre-compress payloads.
+
+---
+
+## Production Limits
+
+- **Single Node Only**: Release 1 has no clustering or shared state.
+- **Memory Only**: Restarting the process clears the cache.
+- **HTTP Payload Cap**: JSON request bodies over 8 MiB are rejected; use gRPC for larger backend payloads.
+- **Capacity Planning Matters**: `CACHE_MAX_ELEMENTS`, response size, and TTL settings all affect RAM usage.
+- **Best Fit**: Place Erion Ember in front of one or more chat backends that can tolerate rebuilding cache state after restarts.
+
+Use shorter TTLs for volatile prompts and lower `CACHE_MAX_ELEMENTS` when running on smaller hosts.
+
+---
+
+## Integration Paths
+
+- **Preferred gRPC path**: Use `proto/ember/v1/semantic_cache.proto` with the Go or Node raw gRPC examples.
+- **HTTP compatibility path**: Use the raw HTTP examples when JSON requests are easier to wire up.
+- **Manual verification path**: Use the HTTP `curl` flow or the showcase script to confirm a miss -> set -> hit cycle before rollout.
 
 ---
 
@@ -69,7 +114,7 @@ The `similarity_threshold` (0.0 to 1.0) controls how strict the matching is.
 
 ### "Cache Miss" for similar text
 - **Problem**: Similarity isn't being detected.
-- **Solution**: Lower the `similarity_threshold`. Ensure the prompts share at least some core keywords, as BM25 relies on term importance.
+- **Solution**: Lower the `similarity_threshold`. Make sure the prompts still share core keywords, because the fallback is lexical rather than embedding-based.
 
 ### "Method Not Allowed"
 - **Problem**: API returns a 405 error.

--- a/docs/plans/2026-03-13-release-1-readiness-design.md
+++ b/docs/plans/2026-03-13-release-1-readiness-design.md
@@ -1,0 +1,38 @@
+# Release 1 Readiness Design
+
+## Status
+- Final release-1 story updated on `2026-03-14` after tasks 1-7 landed in the worktree.
+
+## Release 1 Story
+- Erion Ember release 1 is a self-hosted semantic cache for chat backends.
+- It runs as a single node with in-memory storage only.
+- The runtime keeps the exact-match fast path first and uses BM25 + Jaccard as the lexical fallback.
+- gRPC is the preferred integration surface, with the public contract published at `proto/ember/v1/semantic_cache.proto`.
+- HTTP remains supported for compatibility, smoke tests, demos, and simpler JSON-based integrations.
+
+## Production Shape
+- One process, one node, no persistence.
+- Cache contents are lost on restart.
+- Capacity is bounded in memory by `CACHE_MAX_ELEMENTS` and average response size.
+- TTL and LRU eviction are the main controls for memory pressure.
+- This release is aimed at backend-side prompt/response reuse, not clustered or durable caching.
+
+## Release Docs Index
+- `README.md` - product overview, quickstart, production limits, and validation commands.
+- `docs/USER_GUIDE.md` - operator guidance, first-run workflow, and integration paths.
+- `docs/API_REFERENCE.md` - gRPC and HTTP contract details.
+- `examples/showcase/README.md` - guided demo for a release-ready miss -> hit flow.
+- `examples/go/raw-grpc-chat/main.go` and `examples/node/raw-grpc-chat/index.js` - preferred raw gRPC integrations.
+- `examples/go/raw-http-chat/main.go` and `examples/node/raw-http-chat/index.js` - HTTP compatibility examples.
+
+## Validation Expectations
+- Build from source with `make build`.
+- Run `go test ./...`.
+- Run `go test -race ./...`.
+- Run `golangci-lint run ./...`.
+- Manually verify at least one end-to-end example flow and the showcase script path before release.
+
+## Notes
+- Keep docs explicit that release 1 is memory-only and single-node.
+- Keep docs explicit that gRPC is preferred, not required.
+- Keep command examples aligned with the current binary, ports, proto path, and examples directory layout.

--- a/examples/go/raw-grpc-chat/main.go
+++ b/examples/go/raw-grpc-chat/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	emberv1 "github.com/EricNguyen1206/erion-ember/proto/ember/v1"
+)
+
+const (
+	grpcAddress = "localhost:9090"
+	prompt      = "How do I explain Go channels to a teammate?"
+	ttlSeconds  = int64(3600)
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(grpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("dial gRPC server: %v", err)
+	}
+	defer conn.Close()
+
+	client := emberv1.NewSemanticCacheServiceClient(conn)
+
+	if _, err := client.Health(ctx, &emberv1.HealthRequest{}); err != nil {
+		log.Fatalf("service health check failed: %v", err)
+	}
+
+	firstLookup, err := client.Get(ctx, &emberv1.GetRequest{Prompt: prompt, SimilarityThreshold: 0.85})
+	if err != nil {
+		log.Fatalf("initial cache lookup failed: %v", err)
+	}
+	printLookup("first lookup", firstLookup)
+
+	if !firstLookup.GetHit() {
+		llmResponse := generateLLMResponse(prompt)
+		setResp, err := client.Set(ctx, &emberv1.SetRequest{
+			Prompt:     prompt,
+			Response:   llmResponse,
+			TtlSeconds: ttlSeconds,
+		})
+		if err != nil {
+			log.Fatalf("cache set failed: %v", err)
+		}
+
+		fmt.Printf("cache miss -> placeholder LLM response stored with id=%s\n", setResp.GetId())
+	}
+
+	secondLookup, err := client.Get(ctx, &emberv1.GetRequest{Prompt: prompt, SimilarityThreshold: 0.85})
+	if err != nil {
+		log.Fatalf("follow-up cache lookup failed: %v", err)
+	}
+	printLookup("second lookup", secondLookup)
+
+	stats, err := client.Stats(ctx, &emberv1.StatsRequest{})
+	if err != nil {
+		log.Fatalf("stats lookup failed: %v", err)
+	}
+
+	fmt.Printf("stats: hits=%d misses=%d total_queries=%d\n", stats.GetCacheHits(), stats.GetCacheMisses(), stats.GetTotalQueries())
+}
+
+func generateLLMResponse(prompt string) string {
+	return fmt.Sprintf("[placeholder LLM] A simple answer for %q is: channels let goroutines synchronize and pass work safely.", prompt)
+}
+
+func printLookup(label string, resp *emberv1.GetResponse) {
+	if resp.GetHit() {
+		fmt.Printf("%s: hit=true exact_match=%t similarity=%.2f response=%q\n", label, resp.GetExactMatch(), resp.GetSimilarity(), resp.GetResponse())
+		return
+	}
+
+	fmt.Printf("%s: hit=false -> call your LLM and then cache the answer\n", label)
+}

--- a/examples/go/raw-http-chat/main.go
+++ b/examples/go/raw-http-chat/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+const (
+	httpBaseURL = "http://localhost:8080"
+	prompt      = "How do I explain Go channels to a teammate?"
+	ttlSeconds  = 3600
+)
+
+type getRequest struct {
+	Prompt              string  `json:"prompt"`
+	SimilarityThreshold float32 `json:"similarity_threshold,omitempty"`
+}
+
+type getResponse struct {
+	Hit        bool    `json:"hit"`
+	Response   string  `json:"response,omitempty"`
+	Similarity float32 `json:"similarity"`
+	ExactMatch bool    `json:"exact_match"`
+}
+
+type setRequest struct {
+	Prompt   string `json:"prompt"`
+	Response string `json:"response"`
+	TTL      int    `json:"ttl,omitempty"`
+}
+
+type setResponse struct {
+	ID string `json:"id"`
+}
+
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
+type statsResponse struct {
+	CacheHits    int64 `json:"cache_hits"`
+	CacheMisses  int64 `json:"cache_misses"`
+	TotalQueries int64 `json:"total_queries"`
+}
+
+func main() {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	var health healthResponse
+	requestJSON(client, http.MethodGet, httpBaseURL+"/ready", nil, &health)
+	if health.Status != "ready" {
+		log.Fatalf("service not ready: status=%q", health.Status)
+	}
+
+	var firstLookup getResponse
+	requestJSON(client, http.MethodPost, httpBaseURL+"/v1/cache/get", getRequest{
+		Prompt:              prompt,
+		SimilarityThreshold: 0.85,
+	}, &firstLookup)
+	printLookup("first lookup", firstLookup)
+
+	if !firstLookup.Hit {
+		llmResponse := generateLLMResponse(prompt)
+
+		var setResp setResponse
+		requestJSON(client, http.MethodPost, httpBaseURL+"/v1/cache/set", setRequest{
+			Prompt:   prompt,
+			Response: llmResponse,
+			TTL:      ttlSeconds,
+		}, &setResp)
+
+		fmt.Printf("cache miss -> placeholder LLM response stored with id=%s\n", setResp.ID)
+	}
+
+	var secondLookup getResponse
+	requestJSON(client, http.MethodPost, httpBaseURL+"/v1/cache/get", getRequest{
+		Prompt:              prompt,
+		SimilarityThreshold: 0.85,
+	}, &secondLookup)
+	printLookup("second lookup", secondLookup)
+
+	var stats statsResponse
+	requestJSON(client, http.MethodGet, httpBaseURL+"/v1/stats", nil, &stats)
+	fmt.Printf("stats: hits=%d misses=%d total_queries=%d\n", stats.CacheHits, stats.CacheMisses, stats.TotalQueries)
+}
+
+func requestJSON(client *http.Client, method, url string, body any, dst any) {
+	var payload io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			log.Fatalf("marshal request for %s %s: %v", method, url, err)
+		}
+		payload = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, payload)
+	if err != nil {
+		log.Fatalf("build request for %s %s: %v", method, url, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("send request for %s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			log.Fatalf("read error response for %s %s: %v", method, url, readErr)
+		}
+		log.Fatalf("%s %s failed: status=%s body=%q", method, url, resp.Status, string(data))
+	}
+
+	if dst == nil {
+		return
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		log.Fatalf("decode response for %s %s: %v", method, url, err)
+	}
+}
+
+func generateLLMResponse(prompt string) string {
+	return fmt.Sprintf("[placeholder LLM] A simple answer for %q is: channels let goroutines synchronize and pass work safely.", prompt)
+}
+
+func printLookup(label string, resp getResponse) {
+	if resp.Hit {
+		fmt.Printf("%s: hit=true exact_match=%t similarity=%.2f response=%q\n", label, resp.ExactMatch, resp.Similarity, resp.Response)
+		return
+	}
+
+	fmt.Printf("%s: hit=false -> call your LLM and then cache the answer\n", label)
+}

--- a/examples/node/raw-grpc-chat/index.js
+++ b/examples/node/raw-grpc-chat/index.js
@@ -1,0 +1,92 @@
+const path = require("node:path");
+
+const grpc = require("@grpc/grpc-js");
+const protoLoader = require("@grpc/proto-loader");
+
+const grpcAddress = process.env.ERION_EMBER_GRPC_ADDR || "localhost:9090";
+const prompt = "How do I explain Go channels to a teammate?";
+const ttlSeconds = 3600;
+
+const protoPath = path.resolve(__dirname, "../../../proto/ember/v1/semantic_cache.proto");
+const packageDefinition = protoLoader.loadSync(protoPath, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+const proto = grpc.loadPackageDefinition(packageDefinition).ember.v1;
+
+async function main() {
+  const client = new proto.SemanticCacheService(
+    grpcAddress,
+    grpc.credentials.createInsecure(),
+  );
+
+  try {
+    await unary(client, "Health", {});
+
+    const firstLookup = await unary(client, "Get", {
+      prompt,
+      similarity_threshold: 0.85,
+    });
+    printLookup("first lookup", firstLookup);
+
+    if (!firstLookup.hit) {
+      const llmResponse = generateLLMResponse(prompt);
+      const setResponse = await unary(client, "Set", {
+        prompt,
+        response: llmResponse,
+        ttl_seconds: String(ttlSeconds),
+      });
+
+      console.log(`cache miss -> placeholder LLM response stored with id=${setResponse.id}`);
+    }
+
+    const secondLookup = await unary(client, "Get", {
+      prompt,
+      similarity_threshold: 0.85,
+    });
+    printLookup("second lookup", secondLookup);
+
+    const stats = await unary(client, "Stats", {});
+    console.log(
+      `stats: hits=${stats.cache_hits} misses=${stats.cache_misses} total_queries=${stats.total_queries}`,
+    );
+  } finally {
+    client.close();
+  }
+}
+
+function unary(client, method, request) {
+  return new Promise((resolve, reject) => {
+    client[method](request, (err, response) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(response);
+    });
+  });
+}
+
+function generateLLMResponse(inputPrompt) {
+  return `[placeholder LLM] A simple answer for "${inputPrompt}" is: channels let goroutines synchronize and pass work safely.`;
+}
+
+function printLookup(label, response) {
+  if (response.hit) {
+    console.log(
+      `${label}: hit=true exact_match=${response.exact_match} similarity=${Number(response.similarity).toFixed(2)} response=${JSON.stringify(response.response)}`,
+    );
+    return;
+  }
+
+  console.log(`${label}: hit=false -> call your LLM and then cache the answer`);
+}
+
+main().catch((error) => {
+  console.error(`example failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/examples/node/raw-grpc-chat/package.json
+++ b/examples/node/raw-grpc-chat/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "raw-grpc-chat",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Raw Node.js gRPC example for Erion Ember",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.14.0",
+    "@grpc/proto-loader": "^0.8.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/node/raw-http-chat/index.js
+++ b/examples/node/raw-http-chat/index.js
@@ -1,0 +1,72 @@
+const httpBaseUrl = process.env.ERION_EMBER_HTTP_URL || "http://localhost:8080";
+const prompt = "How do I explain HTTP cache misses to a teammate?";
+const ttlSeconds = 3600;
+
+async function main() {
+  const ready = await requestJSON("GET", "/ready");
+  if (ready.status !== "ready") {
+    throw new Error(`service not ready: status=${JSON.stringify(ready.status)}`);
+  }
+
+  const firstLookup = await requestJSON("POST", "/v1/cache/get", {
+    prompt,
+    similarity_threshold: 0.85,
+  });
+  printLookup("first lookup", firstLookup);
+
+  if (!firstLookup.hit) {
+    const llmResponse = generateLLMResponse(prompt);
+    const setResponse = await requestJSON("POST", "/v1/cache/set", {
+      prompt,
+      response: llmResponse,
+      ttl: ttlSeconds,
+    });
+
+    console.log(`cache miss -> placeholder LLM response stored with id=${setResponse.id}`);
+  }
+
+  const secondLookup = await requestJSON("POST", "/v1/cache/get", {
+    prompt,
+    similarity_threshold: 0.85,
+  });
+  printLookup("second lookup", secondLookup);
+
+  const stats = await requestJSON("GET", "/v1/stats");
+  console.log(
+    `stats: hits=${stats.cache_hits} misses=${stats.cache_misses} total_queries=${stats.total_queries}`,
+  );
+}
+
+async function requestJSON(method, route, body) {
+  const response = await fetch(`${httpBaseUrl}${route}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} ${route} failed: status=${response.status} body=${JSON.stringify(await response.text())}`);
+  }
+
+  return response.json();
+}
+
+function generateLLMResponse(inputPrompt) {
+  return `[placeholder LLM] A simple answer for "${inputPrompt}" is: a cache miss means the requested response was not found yet, so your app should call the upstream model and then store the new answer.`;
+}
+
+function printLookup(label, response) {
+  if (response.hit) {
+    console.log(
+      `${label}: hit=true exact_match=${response.exact_match} similarity=${Number(response.similarity).toFixed(2)} response=${JSON.stringify(response.response)}`,
+    );
+    return;
+  }
+
+  console.log(`${label}: hit=false -> call your LLM and then cache the answer`);
+}
+
+main().catch((error) => {
+  console.error(`example failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/examples/node/raw-http-chat/package.json
+++ b/examples/node/raw-http-chat/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "raw-http-chat",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Raw Node.js HTTP example for Erion Ember",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -1,0 +1,36 @@
+## Showcase Demo
+
+This sandbox gives you a near-one-command release demo for Erion Ember using Docker Compose.
+
+Prerequisites:
+
+- Docker with `docker compose`
+- `curl`
+- optional `jq` for prettier JSON output
+
+From the repository root:
+
+```bash
+./examples/showcase/scripts/run-demo.sh
+```
+
+What it does:
+
+- Starts a dedicated demo stack on HTTP `18080` and gRPC `19090`
+- Builds the local release image as `erion-ember:local`
+- Waits for the service to report ready
+- Shows a cache miss for a realistic chat prompt
+- Stores a placeholder LLM answer
+- Repeats the lookup to show a cache hit
+- Prints `/v1/stats` and selected `/metrics` lines before and after the demo
+
+Stop the showcase stack when you are done:
+
+```bash
+docker compose -f examples/showcase/docker-compose.yml down
+```
+
+Notes:
+
+- The script keeps the container running after the demo so you can keep exploring
+- If you already have something on `18080` or `19090`, stop it or adjust the compose ports first

--- a/examples/showcase/docker-compose.yml
+++ b/examples/showcase/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  ember-showcase:
+    image: erion-ember:local
+    ports:
+      - "18080:8080"
+      - "19090:9090"
+    environment:
+      HTTP_PORT: "8080"
+      GRPC_PORT: "9090"
+      CACHE_MAX_ELEMENTS: "1000"
+      CACHE_DEFAULT_TTL: "3600"
+      CACHE_SIMILARITY_THRESHOLD: "0.85"
+    restart: unless-stopped

--- a/examples/showcase/scripts/run-demo.sh
+++ b/examples/showcase/scripts/run-demo.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHOWCASE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE="${SHOWCASE_DIR}/docker-compose.yml"
+BASE_URL="http://127.0.0.1:18080"
+PROMPT="How should a chat backend explain cache warming during a release demo?"
+RESPONSE="Cache warming means the first request misses, the backend calls the LLM once, and the second request is served directly from Erion Ember."
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+print_json() {
+  if command -v jq >/dev/null 2>&1; then
+    jq .
+    return
+  fi
+
+  cat
+}
+
+extract_metric() {
+  local metric_name="$1"
+  while IFS= read -r line; do
+    if [[ "$line" == "$metric_name "* ]]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+post_json() {
+  local path="$1"
+  local payload="$2"
+  curl --silent --show-error --fail \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "${BASE_URL}${path}"
+}
+
+wait_for_ready() {
+  printf 'Waiting for Erion Ember on %s' "$BASE_URL"
+  for _ in $(seq 1 60); do
+    if curl --silent --fail "${BASE_URL}/ready" >/dev/null 2>&1; then
+      printf ' ready\n'
+      return 0
+    fi
+    printf '.'
+    sleep 1
+  done
+  printf '\nservice did not become ready in time\n' >&2
+  exit 1
+}
+
+show_stats() {
+  local label="$1"
+  printf '\n%s stats\n' "$label"
+  curl --silent --show-error --fail "${BASE_URL}/v1/stats" | print_json
+}
+
+show_metrics() {
+  local label="$1"
+  local metrics
+  metrics="$(curl --silent --show-error --fail "${BASE_URL}/metrics")"
+
+  printf '\n%s metrics\n' "$label"
+  printf '%s\n' "$metrics" | extract_metric "erion_ember_cache_entries"
+  printf '%s\n' "$metrics" | extract_metric "erion_ember_cache_hits_total"
+  printf '%s\n' "$metrics" | extract_metric "erion_ember_cache_misses_total"
+  printf '%s\n' "$metrics" | extract_metric "erion_ember_cache_queries_total"
+  printf '%s\n' "$metrics" | extract_metric "erion_ember_cache_hit_rate"
+}
+
+show_lookup() {
+  local label="$1"
+  local payload
+  payload="{\"prompt\":\"${PROMPT}\",\"similarity_threshold\":0.85}"
+
+  printf '\n%s\n' "$label"
+  post_json "/v1/cache/get" "$payload" | print_json
+}
+
+require_command docker
+require_command curl
+
+printf 'Starting showcase stack from %s\n' "$COMPOSE_FILE"
+docker build -t erion-ember:local "${SHOWCASE_DIR}/../.."
+docker compose -f "$COMPOSE_FILE" up -d --force-recreate --remove-orphans
+
+wait_for_ready
+
+show_stats "Before demo"
+show_metrics "Before demo"
+show_lookup "First lookup: expect miss"
+
+printf '\nStoring placeholder LLM response\n'
+post_json "/v1/cache/set" "{\"prompt\":\"${PROMPT}\",\"response\":\"${RESPONSE}\",\"ttl\":3600}" | print_json
+
+show_lookup "Second lookup: expect hit"
+show_stats "After demo"
+show_metrics "After demo"
+
+printf '\nShowcase complete. The container is still running for follow-up demos.\n'
+printf 'Stop it with: docker compose -f %s down\n' "$COMPOSE_FILE"

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	emberv1 "github.com/EricNguyen1206/erion-ember/proto/ember/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,7 +27,7 @@ func NewGRPCServer(addr string, sc *cache.SemanticCache) (*GRPCServer, error) {
 	}
 
 	grpcServer := grpc.NewServer()
-	RegisterSemanticCacheServiceServer(grpcServer, &semanticCacheService{cache: sc})
+	emberv1.RegisterSemanticCacheServiceServer(grpcServer, &semanticCacheService{cache: sc})
 
 	return &GRPCServer{listener: listener, server: grpcServer}, nil
 }
@@ -46,17 +47,25 @@ func (s *GRPCServer) Stop() {
 }
 
 type semanticCacheService struct {
-	UnimplementedSemanticCacheServiceServer
+	emberv1.UnimplementedSemanticCacheServiceServer
 	cache *cache.SemanticCache
 }
 
-func (s *semanticCacheService) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
+func (s *semanticCacheService) ready() bool {
+	return s != nil && s.cache != nil
+}
+
+func (s *semanticCacheService) Get(ctx context.Context, req *emberv1.GetRequest) (*emberv1.GetResponse, error) {
+	if !s.ready() {
+		return nil, status.Error(codes.Unavailable, "service not ready")
+	}
+
 	if req == nil || !hasText(req.Prompt) {
 		return nil, status.Error(codes.InvalidArgument, "prompt is required")
 	}
 
 	result, hit := s.cache.Get(ctx, req.Prompt, req.SimilarityThreshold)
-	resp := &GetResponse{Hit: hit}
+	resp := &emberv1.GetResponse{Hit: hit}
 	if hit && result != nil {
 		resp.Response = result.Response
 		resp.Similarity = result.Similarity
@@ -66,7 +75,11 @@ func (s *semanticCacheService) Get(ctx context.Context, req *GetRequest) (*GetRe
 	return resp, nil
 }
 
-func (s *semanticCacheService) Set(ctx context.Context, req *SetRequest) (*SetResponse, error) {
+func (s *semanticCacheService) Set(ctx context.Context, req *emberv1.SetRequest) (*emberv1.SetResponse, error) {
+	if !s.ready() {
+		return nil, status.Error(codes.Unavailable, "service not ready")
+	}
+
 	if req == nil || !hasText(req.Prompt) || !hasText(req.Response) {
 		return nil, status.Error(codes.InvalidArgument, "prompt and response are required")
 	}
@@ -79,20 +92,28 @@ func (s *semanticCacheService) Set(ctx context.Context, req *SetRequest) (*SetRe
 		return nil, status.Errorf(codes.Internal, "set cache entry: %v", err)
 	}
 
-	return &SetResponse{Id: id}, nil
+	return &emberv1.SetResponse{Id: id}, nil
 }
 
-func (s *semanticCacheService) Delete(ctx context.Context, req *DeleteRequest) (*DeleteResponse, error) {
+func (s *semanticCacheService) Delete(ctx context.Context, req *emberv1.DeleteRequest) (*emberv1.DeleteResponse, error) {
+	if !s.ready() {
+		return nil, status.Error(codes.Unavailable, "service not ready")
+	}
+
 	if req == nil || !hasText(req.Prompt) {
 		return nil, status.Error(codes.InvalidArgument, "prompt is required")
 	}
 
-	return &DeleteResponse{Deleted: s.cache.Delete(req.Prompt)}, nil
+	return &emberv1.DeleteResponse{Deleted: s.cache.Delete(req.Prompt)}, nil
 }
 
-func (s *semanticCacheService) Stats(ctx context.Context, req *StatsRequest) (*StatsResponse, error) {
+func (s *semanticCacheService) Stats(ctx context.Context, req *emberv1.StatsRequest) (*emberv1.StatsResponse, error) {
+	if !s.ready() {
+		return nil, status.Error(codes.Unavailable, "service not ready")
+	}
+
 	st := s.cache.Stats()
-	return &StatsResponse{
+	return &emberv1.StatsResponse{
 		TotalEntries: int64(st.TotalEntries),
 		CacheHits:    st.CacheHits,
 		CacheMisses:  st.CacheMisses,
@@ -101,6 +122,10 @@ func (s *semanticCacheService) Stats(ctx context.Context, req *StatsRequest) (*S
 	}, nil
 }
 
-func (s *semanticCacheService) Health(ctx context.Context, req *HealthRequest) (*HealthResponse, error) {
-	return &HealthResponse{Status: "ok"}, nil
+func (s *semanticCacheService) Health(ctx context.Context, req *emberv1.HealthRequest) (*emberv1.HealthResponse, error) {
+	if !s.ready() {
+		return nil, status.Error(codes.Unavailable, "service not ready")
+	}
+
+	return &emberv1.HealthResponse{Status: "ready"}, nil
 }

--- a/internal/server/grpc_test.go
+++ b/internal/server/grpc_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"testing"
 
+	emberv1 "github.com/EricNguyen1206/erion-ember/proto/ember/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -18,7 +19,7 @@ func TestGRPCServiceCRUDFlow(t *testing.T) {
 
 	ctx := context.Background()
 
-	setResponse, err := client.Set(ctx, &SetRequest{
+	setResponse, err := client.Set(ctx, &emberv1.SetRequest{
 		Prompt:   "What is Go?",
 		Response: "Go is a compiled language.",
 	})
@@ -29,7 +30,7 @@ func TestGRPCServiceCRUDFlow(t *testing.T) {
 		t.Fatal("expected non-empty cache id")
 	}
 
-	getResponse, err := client.Get(ctx, &GetRequest{Prompt: "What is Go?"})
+	getResponse, err := client.Get(ctx, &emberv1.GetRequest{Prompt: "What is Go?"})
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -40,7 +41,7 @@ func TestGRPCServiceCRUDFlow(t *testing.T) {
 		t.Fatal("expected exact match")
 	}
 
-	statsResponse, err := client.Stats(ctx, &StatsRequest{})
+	statsResponse, err := client.Stats(ctx, &emberv1.StatsRequest{})
 	if err != nil {
 		t.Fatalf("Stats failed: %v", err)
 	}
@@ -48,7 +49,7 @@ func TestGRPCServiceCRUDFlow(t *testing.T) {
 		t.Fatalf("got %d entries, want 1", statsResponse.TotalEntries)
 	}
 
-	deleteResponse, err := client.Delete(ctx, &DeleteRequest{Prompt: "What is Go?"})
+	deleteResponse, err := client.Delete(ctx, &emberv1.DeleteRequest{Prompt: "What is Go?"})
 	if err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
@@ -56,7 +57,7 @@ func TestGRPCServiceCRUDFlow(t *testing.T) {
 		t.Fatal("expected delete success")
 	}
 
-	getResponse, err = client.Get(ctx, &GetRequest{Prompt: "What is Go?"})
+	getResponse, err = client.Get(ctx, &emberv1.GetRequest{Prompt: "What is Go?"})
 	if err != nil {
 		t.Fatalf("Get after delete failed: %v", err)
 	}
@@ -64,11 +65,11 @@ func TestGRPCServiceCRUDFlow(t *testing.T) {
 		t.Fatal("expected miss after delete")
 	}
 
-	healthResponse, err := client.Health(ctx, &HealthRequest{})
+	healthResponse, err := client.Health(ctx, &emberv1.HealthRequest{})
 	if err != nil {
 		t.Fatalf("Health failed: %v", err)
 	}
-	if healthResponse.Status != "ok" {
+	if healthResponse.Status != "ready" {
 		t.Fatalf("got health status %q", healthResponse.Status)
 	}
 }
@@ -77,23 +78,54 @@ func TestGRPCServiceValidation(t *testing.T) {
 	client, cleanup := newBufconnClient(t)
 	defer cleanup()
 
-	_, err := client.Set(context.Background(), &SetRequest{Prompt: " ", Response: "value"})
+	_, err := client.Set(context.Background(), &emberv1.SetRequest{Prompt: " ", Response: "value"})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("got code %s, want %s", status.Code(err), codes.InvalidArgument)
 	}
 
-	_, err = client.Set(context.Background(), &SetRequest{Prompt: "prompt", Response: "value", TtlSeconds: -1})
+	_, err = client.Set(context.Background(), &emberv1.SetRequest{Prompt: "prompt", Response: "value", TtlSeconds: -1})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("got code %s, want %s", status.Code(err), codes.InvalidArgument)
 	}
 }
 
-func newBufconnClient(t *testing.T) (SemanticCacheServiceClient, func()) {
+func TestGRPCServiceHealthReportsReadiness(t *testing.T) {
+	client, cleanup := newBufconnClient(t)
+	defer cleanup()
+
+	resp, err := client.Health(context.Background(), &emberv1.HealthRequest{})
+	if err != nil {
+		t.Fatalf("Health failed: %v", err)
+	}
+	if resp.Status != "ready" {
+		t.Fatalf("got health status %q, want %q", resp.Status, "ready")
+	}
+}
+
+func TestGRPCServiceHealthRequiresInitializedCache(t *testing.T) {
+	service := &semanticCacheService{}
+
+	_, err := service.Health(context.Background(), &emberv1.HealthRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("got code %s, want %s", status.Code(err), codes.Unavailable)
+	}
+}
+
+func TestGRPCServiceGetRequiresInitializedCache(t *testing.T) {
+	service := &semanticCacheService{}
+
+	_, err := service.Get(context.Background(), &emberv1.GetRequest{Prompt: "What is Go?"})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("got code %s, want %s", status.Code(err), codes.Unavailable)
+	}
+}
+
+func newBufconnClient(t *testing.T) (emberv1.SemanticCacheServiceClient, func()) {
 	t.Helper()
 
 	listener := bufconn.Listen(1024 * 1024)
 	grpcServer := grpc.NewServer()
-	RegisterSemanticCacheServiceServer(grpcServer, &semanticCacheService{cache: newServerTestCache()})
+	emberv1.RegisterSemanticCacheServiceServer(grpcServer, &semanticCacheService{cache: newServerTestCache()})
 
 	go func() {
 		_ = grpcServer.Serve(listener)
@@ -120,5 +152,5 @@ func newBufconnClient(t *testing.T) (SemanticCacheServiceClient, func()) {
 		_ = listener.Close()
 	}
 
-	return NewSemanticCacheServiceClient(conn), cleanup
+	return emberv1.NewSemanticCacheServiceClient(conn), cleanup
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/EricNguyen1206/erion-ember/internal/cache"
@@ -18,6 +22,7 @@ const (
 	httpReadTimeout       = 15 * time.Second
 	httpWriteTimeout      = 15 * time.Second
 	httpIdleTimeout       = 60 * time.Second
+	maxRequestBodyBytes   = 8 << 20
 )
 
 // HTTPServer exposes SemanticCache over REST/JSON.
@@ -27,6 +32,32 @@ type HTTPServer struct {
 
 type httpHandler struct {
 	cache *cache.SemanticCache
+	stats *httpMetrics
+}
+
+type httpMetrics struct {
+	mu       sync.Mutex
+	requests map[requestMetricKey]*requestMetric
+}
+
+type requestMetricKey struct {
+	Method string
+	Path   string
+	Status int
+}
+
+type requestMetric struct {
+	Count       int64
+	DurationSum time.Duration
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (h *httpHandler) ready() bool {
+	return h != nil && h.cache != nil
 }
 
 func NewHTTPServer(addr string, sc *cache.SemanticCache) *HTTPServer {
@@ -43,14 +74,16 @@ func NewHTTPServer(addr string, sc *cache.SemanticCache) *HTTPServer {
 }
 
 func NewHTTPHandler(sc *cache.SemanticCache) http.Handler {
-	h := &httpHandler{cache: sc}
+	h := &httpHandler{cache: sc, stats: newHTTPMetrics()}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/cache/get", h.handleGet)
 	mux.HandleFunc("POST /v1/cache/set", h.handleSet)
 	mux.HandleFunc("POST /v1/cache/delete", h.handleDelete)
 	mux.HandleFunc("GET /v1/stats", h.handleStats)
+	mux.HandleFunc("GET /metrics", h.handleMetrics)
 	mux.HandleFunc("GET /health", h.handleHealth)
-	return mux
+	mux.HandleFunc("GET /ready", h.handleReady)
+	return h.withObservability(mux)
 }
 
 func (s *HTTPServer) ListenAndServe() error              { return s.server.ListenAndServe() }
@@ -95,8 +128,17 @@ type statsResp struct {
 }
 
 func (h *httpHandler) handleGet(w http.ResponseWriter, r *http.Request) {
+	if !h.ready() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "not_ready"})
+		return
+	}
+
 	var req getReq
-	if err := decodeJSON(r, &req); err != nil || !hasText(req.Prompt) {
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeDecodeError(w, err, "prompt is required")
+		return
+	}
+	if !hasText(req.Prompt) {
 		http.Error(w, "prompt is required", http.StatusBadRequest)
 		return
 	}
@@ -113,8 +155,17 @@ func (h *httpHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *httpHandler) handleSet(w http.ResponseWriter, r *http.Request) {
+	if !h.ready() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "not_ready"})
+		return
+	}
+
 	var req setReq
-	if err := decodeJSON(r, &req); err != nil || !hasText(req.Prompt) || !hasText(req.Response) {
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeDecodeError(w, err, "prompt and response are required")
+		return
+	}
+	if !hasText(req.Prompt) || !hasText(req.Response) {
 		http.Error(w, "prompt and response are required", http.StatusBadRequest)
 		return
 	}
@@ -134,8 +185,17 @@ func (h *httpHandler) handleSet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *httpHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if !h.ready() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "not_ready"})
+		return
+	}
+
 	var req deleteReq
-	if err := decodeJSON(r, &req); err != nil || !hasText(req.Prompt) {
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeDecodeError(w, err, "prompt is required")
+		return
+	}
+	if !hasText(req.Prompt) {
 		http.Error(w, "prompt is required", http.StatusBadRequest)
 		return
 	}
@@ -144,6 +204,11 @@ func (h *httpHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *httpHandler) handleStats(w http.ResponseWriter, r *http.Request) {
+	if !h.ready() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "not_ready"})
+		return
+	}
+
 	st := h.cache.Stats()
 	writeJSON(w, http.StatusOK, statsResp{
 		TotalEntries: int64(st.TotalEntries),
@@ -154,12 +219,42 @@ func (h *httpHandler) handleStats(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *httpHandler) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	w.WriteHeader(http.StatusOK)
+
+	if h.stats != nil {
+		_, _ = io.WriteString(w, h.stats.render())
+	}
+
+	if h.cache == nil {
+		return
+	}
+
+	st := h.cache.Stats()
+	_, _ = fmt.Fprintf(w, "erion_ember_cache_entries %d\n", st.TotalEntries)
+	_, _ = fmt.Fprintf(w, "erion_ember_cache_hits_total %d\n", st.CacheHits)
+	_, _ = fmt.Fprintf(w, "erion_ember_cache_misses_total %d\n", st.CacheMisses)
+	_, _ = fmt.Fprintf(w, "erion_ember_cache_queries_total %d\n", st.TotalQueries)
+	_, _ = fmt.Fprintf(w, "erion_ember_cache_hit_rate %g\n", st.HitRate)
+}
+
 func (h *httpHandler) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-func decodeJSON(r *http.Request, dst any) error {
+func (h *httpHandler) handleReady(w http.ResponseWriter, r *http.Request) {
+	if !h.ready() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "not_ready"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) error {
 	defer r.Body.Close()
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
@@ -177,6 +272,20 @@ func decodeJSON(r *http.Request, dst any) error {
 	return errors.New("request body must contain a single JSON object")
 }
 
+func writeDecodeError(w http.ResponseWriter, err error, fallback string) {
+	if isRequestTooLarge(err) {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	http.Error(w, fallback, http.StatusBadRequest)
+}
+
+func isRequestTooLarge(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}
+
 func hasText(value string) bool {
 	return strings.TrimSpace(value) != ""
 }
@@ -185,4 +294,79 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newHTTPMetrics() *httpMetrics {
+	return &httpMetrics{requests: make(map[requestMetricKey]*requestMetric)}
+}
+
+func (h *httpHandler) withObservability(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startedAt := time.Now()
+		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(recorder, r)
+
+		duration := time.Since(startedAt)
+		if h.stats != nil {
+			h.stats.record(r.Method, r.URL.Path, recorder.status, duration)
+		}
+
+		slog.Debug("http request completed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", recorder.status,
+			"duration", duration,
+		)
+	})
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (m *httpMetrics) record(method, path string, status int, duration time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := requestMetricKey{Method: method, Path: path, Status: status}
+	metric := m.requests[key]
+	if metric == nil {
+		metric = &requestMetric{}
+		m.requests[key] = metric
+	}
+
+	metric.Count++
+	metric.DurationSum += duration
+}
+
+func (m *httpMetrics) render() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keys := make([]requestMetricKey, 0, len(m.requests))
+	for key := range m.requests {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Path != keys[j].Path {
+			return keys[i].Path < keys[j].Path
+		}
+		if keys[i].Method != keys[j].Method {
+			return keys[i].Method < keys[j].Method
+		}
+		return keys[i].Status < keys[j].Status
+	})
+
+	var b strings.Builder
+	for _, key := range keys {
+		metric := m.requests[key]
+		labels := fmt.Sprintf("method=%q,path=%q,status=%q", key.Method, key.Path, strconv.Itoa(key.Status))
+		_, _ = fmt.Fprintf(&b, "erion_ember_http_requests_total{%s} %d\n", labels, metric.Count)
+		_, _ = fmt.Fprintf(&b, "erion_ember_http_request_duration_seconds_sum{%s} %.9f\n", labels, metric.DurationSum.Seconds())
+		_, _ = fmt.Fprintf(&b, "erion_ember_http_request_duration_seconds_count{%s} %d\n", labels, metric.Count)
+	}
+
+	return b.String()
 }

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -2,14 +2,58 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/EricNguyen1206/erion-ember/internal/cache"
 )
+
+type logRecord struct {
+	Level   slog.Level
+	Message string
+}
+
+type captureHandler struct {
+	mu      sync.Mutex
+	records []logRecord
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (h *captureHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, logRecord{Level: record.Level, Message: record.Message})
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+
+func (h *captureHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *captureHandler) count(level slog.Level, message string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	count := 0
+	for _, record := range h.records {
+		if record.Level == level && record.Message == message {
+			count++
+		}
+	}
+
+	return count
+}
 
 func newServerTestCache() *cache.SemanticCache {
 	return cache.New(cache.Config{
@@ -83,6 +127,158 @@ func TestHTTPHandlerValidation(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("got status %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestHTTPHandlerRejectsOversizedRequestBody(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(newServerTestCache()))
+	defer ts.Close()
+
+	body := `{"prompt":"` + strings.Repeat("a", maxRequestBodyBytes+1) + `"}`
+	resp, err := http.Post(ts.URL+"/v1/cache/get", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST oversized get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got status %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestHTTPHandlerAcceptsLargeButReasonableRequestBody(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(newServerTestCache()))
+	defer ts.Close()
+
+	body := setReq{
+		Prompt:   "large-prompt",
+		Response: strings.Repeat("a", 2<<20),
+	}
+
+	var respBody setResp
+	postJSON(t, ts.URL+"/v1/cache/set", body, http.StatusOK, &respBody)
+	if respBody.ID == "" {
+		t.Fatal("expected non-empty cache id")
+	}
+}
+
+func TestHTTPHandlerHealthAndReadinessAreDistinct(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(newServerTestCache()))
+	defer ts.Close()
+
+	var health map[string]string
+	getJSON(t, ts.URL+"/health", http.StatusOK, &health)
+	if health["status"] != "ok" {
+		t.Fatalf("got health status %q", health["status"])
+	}
+
+	var readiness map[string]string
+	getJSON(t, ts.URL+"/ready", http.StatusOK, &readiness)
+	if readiness["status"] != "ready" {
+		t.Fatalf("got readiness status %q", readiness["status"])
+	}
+}
+
+func TestHTTPHandlerReadinessRequiresInitializedCache(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(nil))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/ready")
+	if err != nil {
+		t.Fatalf("GET /ready: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("got status %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	var readiness map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&readiness); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if readiness["status"] != "not_ready" {
+		t.Fatalf("got readiness status %q", readiness["status"])
+	}
+}
+
+func TestHTTPHandlerRejectsRequestsWhenNotReady(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(nil))
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/cache/get", "application/json", strings.NewReader(`{"prompt":"What is Go?"}`))
+	if err != nil {
+		t.Fatalf("POST /v1/cache/get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("got status %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+}
+
+func TestHTTPHandlerExposesMetrics(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(newServerTestCache()))
+	defer ts.Close()
+
+	postJSONStatus(t, ts.URL+"/v1/cache/set", setReq{
+		Prompt:   "What is Go?",
+		Response: "Go is a compiled language.",
+	}, http.StatusOK)
+	postJSONStatus(t, ts.URL+"/v1/cache/get", getReq{Prompt: "What is Go?"}, http.StatusOK)
+	postJSONStatus(t, ts.URL+"/v1/cache/get", getReq{Prompt: "What is Rust?"}, http.StatusOK)
+
+	resp, err := http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read metrics body: %v", err)
+	}
+
+	text := string(body)
+	for _, want := range []string{
+		`erion_ember_http_requests_total{method="POST",path="/v1/cache/get",status="200"} 2`,
+		`erion_ember_http_request_duration_seconds_count{method="POST",path="/v1/cache/get",status="200"} 2`,
+		`erion_ember_cache_hits_total 1`,
+		`erion_ember_cache_misses_total 1`,
+		`erion_ember_cache_queries_total 2`,
+		`erion_ember_cache_entries 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("metrics output missing %q\n%s", want, text)
+		}
+	}
+}
+
+func TestHTTPHandlerLogsRequestsAtDebugLevel(t *testing.T) {
+	ts := httptest.NewServer(NewHTTPHandler(newServerTestCache()))
+	defer ts.Close()
+
+	handler := &captureHandler{}
+	logger := slog.New(handler)
+	previous := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(previous)
+
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if handler.count(slog.LevelInfo, "http request completed") != 0 {
+		t.Fatal("expected no info-level request logs")
+	}
+	if handler.count(slog.LevelDebug, "http request completed") == 0 {
+		t.Fatal("expected debug-level request log")
 	}
 }
 

--- a/proto/ember/v1/semantic_cache.pb.go
+++ b/proto/ember/v1/semantic_cache.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // 	protoc-gen-go v1.36.6
 // 	protoc        v5.28.3
-// source: internal/server/semantic_cache.proto
+// source: proto/ember/v1/semantic_cache.proto
 
-package server
+package emberv1
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -31,7 +31,7 @@ type GetRequest struct {
 
 func (x *GetRequest) Reset() {
 	*x = GetRequest{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[0]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -43,7 +43,7 @@ func (x *GetRequest) String() string {
 func (*GetRequest) ProtoMessage() {}
 
 func (x *GetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[0]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56,7 +56,7 @@ func (x *GetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRequest.ProtoReflect.Descriptor instead.
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{0}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *GetRequest) GetPrompt() string {
@@ -85,7 +85,7 @@ type GetResponse struct {
 
 func (x *GetResponse) Reset() {
 	*x = GetResponse{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[1]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -97,7 +97,7 @@ func (x *GetResponse) String() string {
 func (*GetResponse) ProtoMessage() {}
 
 func (x *GetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[1]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -110,7 +110,7 @@ func (x *GetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetResponse.ProtoReflect.Descriptor instead.
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{1}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *GetResponse) GetHit() bool {
@@ -152,7 +152,7 @@ type SetRequest struct {
 
 func (x *SetRequest) Reset() {
 	*x = SetRequest{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[2]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -164,7 +164,7 @@ func (x *SetRequest) String() string {
 func (*SetRequest) ProtoMessage() {}
 
 func (x *SetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[2]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -177,7 +177,7 @@ func (x *SetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetRequest.ProtoReflect.Descriptor instead.
 func (*SetRequest) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{2}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *SetRequest) GetPrompt() string {
@@ -210,7 +210,7 @@ type SetResponse struct {
 
 func (x *SetResponse) Reset() {
 	*x = SetResponse{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[3]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -222,7 +222,7 @@ func (x *SetResponse) String() string {
 func (*SetResponse) ProtoMessage() {}
 
 func (x *SetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[3]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -235,7 +235,7 @@ func (x *SetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetResponse.ProtoReflect.Descriptor instead.
 func (*SetResponse) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{3}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *SetResponse) GetId() string {
@@ -254,7 +254,7 @@ type DeleteRequest struct {
 
 func (x *DeleteRequest) Reset() {
 	*x = DeleteRequest{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[4]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -266,7 +266,7 @@ func (x *DeleteRequest) String() string {
 func (*DeleteRequest) ProtoMessage() {}
 
 func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[4]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -279,7 +279,7 @@ func (x *DeleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{4}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *DeleteRequest) GetPrompt() string {
@@ -298,7 +298,7 @@ type DeleteResponse struct {
 
 func (x *DeleteResponse) Reset() {
 	*x = DeleteResponse{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[5]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -310,7 +310,7 @@ func (x *DeleteResponse) String() string {
 func (*DeleteResponse) ProtoMessage() {}
 
 func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[5]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -323,7 +323,7 @@ func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteResponse.ProtoReflect.Descriptor instead.
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{5}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DeleteResponse) GetDeleted() bool {
@@ -341,7 +341,7 @@ type StatsRequest struct {
 
 func (x *StatsRequest) Reset() {
 	*x = StatsRequest{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[6]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -353,7 +353,7 @@ func (x *StatsRequest) String() string {
 func (*StatsRequest) ProtoMessage() {}
 
 func (x *StatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[6]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -366,7 +366,7 @@ func (x *StatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatsRequest.ProtoReflect.Descriptor instead.
 func (*StatsRequest) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{6}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{6}
 }
 
 type StatsResponse struct {
@@ -382,7 +382,7 @@ type StatsResponse struct {
 
 func (x *StatsResponse) Reset() {
 	*x = StatsResponse{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[7]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -394,7 +394,7 @@ func (x *StatsResponse) String() string {
 func (*StatsResponse) ProtoMessage() {}
 
 func (x *StatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[7]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -407,7 +407,7 @@ func (x *StatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatsResponse.ProtoReflect.Descriptor instead.
 func (*StatsResponse) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{7}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *StatsResponse) GetTotalEntries() int64 {
@@ -453,7 +453,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[8]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -465,7 +465,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[8]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -478,7 +478,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{8}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{8}
 }
 
 type HealthResponse struct {
@@ -490,7 +490,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[9]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -502,7 +502,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_server_semantic_cache_proto_msgTypes[9]
+	mi := &file_proto_ember_v1_semantic_cache_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -515,7 +515,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_internal_server_semantic_cache_proto_rawDescGZIP(), []int{9}
+	return file_proto_ember_v1_semantic_cache_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -525,11 +525,11 @@ func (x *HealthResponse) GetStatus() string {
 	return ""
 }
 
-var File_internal_server_semantic_cache_proto protoreflect.FileDescriptor
+var File_proto_ember_v1_semantic_cache_proto protoreflect.FileDescriptor
 
-const file_internal_server_semantic_cache_proto_rawDesc = "" +
+const file_proto_ember_v1_semantic_cache_proto_rawDesc = "" +
 	"\n" +
-	"$internal/server/semantic_cache.proto\x12\bember.v1\"W\n" +
+	"#proto/ember/v1/semantic_cache.proto\x12\bember.v1\"W\n" +
 	"\n" +
 	"GetRequest\x12\x16\n" +
 	"\x06prompt\x18\x01 \x01(\tR\x06prompt\x121\n" +
@@ -570,22 +570,22 @@ const file_internal_server_semantic_cache_proto_rawDesc = "" +
 	"\x03Set\x12\x14.ember.v1.SetRequest\x1a\x15.ember.v1.SetResponse\x12;\n" +
 	"\x06Delete\x12\x17.ember.v1.DeleteRequest\x1a\x18.ember.v1.DeleteResponse\x128\n" +
 	"\x05Stats\x12\x16.ember.v1.StatsRequest\x1a\x17.ember.v1.StatsResponse\x12;\n" +
-	"\x06Health\x12\x17.ember.v1.HealthRequest\x1a\x18.ember.v1.HealthResponseB>Z<github.com/EricNguyen1206/erion-ember/internal/server;serverb\x06proto3"
+	"\x06Health\x12\x17.ember.v1.HealthRequest\x1a\x18.ember.v1.HealthResponseB>Z<github.com/EricNguyen1206/erion-ember/proto/ember/v1;emberv1b\x06proto3"
 
 var (
-	file_internal_server_semantic_cache_proto_rawDescOnce sync.Once
-	file_internal_server_semantic_cache_proto_rawDescData []byte
+	file_proto_ember_v1_semantic_cache_proto_rawDescOnce sync.Once
+	file_proto_ember_v1_semantic_cache_proto_rawDescData []byte
 )
 
-func file_internal_server_semantic_cache_proto_rawDescGZIP() []byte {
-	file_internal_server_semantic_cache_proto_rawDescOnce.Do(func() {
-		file_internal_server_semantic_cache_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_internal_server_semantic_cache_proto_rawDesc), len(file_internal_server_semantic_cache_proto_rawDesc)))
+func file_proto_ember_v1_semantic_cache_proto_rawDescGZIP() []byte {
+	file_proto_ember_v1_semantic_cache_proto_rawDescOnce.Do(func() {
+		file_proto_ember_v1_semantic_cache_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_proto_ember_v1_semantic_cache_proto_rawDesc), len(file_proto_ember_v1_semantic_cache_proto_rawDesc)))
 	})
-	return file_internal_server_semantic_cache_proto_rawDescData
+	return file_proto_ember_v1_semantic_cache_proto_rawDescData
 }
 
-var file_internal_server_semantic_cache_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
-var file_internal_server_semantic_cache_proto_goTypes = []any{
+var file_proto_ember_v1_semantic_cache_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_proto_ember_v1_semantic_cache_proto_goTypes = []any{
 	(*GetRequest)(nil),     // 0: ember.v1.GetRequest
 	(*GetResponse)(nil),    // 1: ember.v1.GetResponse
 	(*SetRequest)(nil),     // 2: ember.v1.SetRequest
@@ -597,7 +597,7 @@ var file_internal_server_semantic_cache_proto_goTypes = []any{
 	(*HealthRequest)(nil),  // 8: ember.v1.HealthRequest
 	(*HealthResponse)(nil), // 9: ember.v1.HealthResponse
 }
-var file_internal_server_semantic_cache_proto_depIdxs = []int32{
+var file_proto_ember_v1_semantic_cache_proto_depIdxs = []int32{
 	0, // 0: ember.v1.SemanticCacheService.Get:input_type -> ember.v1.GetRequest
 	2, // 1: ember.v1.SemanticCacheService.Set:input_type -> ember.v1.SetRequest
 	4, // 2: ember.v1.SemanticCacheService.Delete:input_type -> ember.v1.DeleteRequest
@@ -615,26 +615,26 @@ var file_internal_server_semantic_cache_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for field type_name
 }
 
-func init() { file_internal_server_semantic_cache_proto_init() }
-func file_internal_server_semantic_cache_proto_init() {
-	if File_internal_server_semantic_cache_proto != nil {
+func init() { file_proto_ember_v1_semantic_cache_proto_init() }
+func file_proto_ember_v1_semantic_cache_proto_init() {
+	if File_proto_ember_v1_semantic_cache_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_server_semantic_cache_proto_rawDesc), len(file_internal_server_semantic_cache_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_ember_v1_semantic_cache_proto_rawDesc), len(file_proto_ember_v1_semantic_cache_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_internal_server_semantic_cache_proto_goTypes,
-		DependencyIndexes: file_internal_server_semantic_cache_proto_depIdxs,
-		MessageInfos:      file_internal_server_semantic_cache_proto_msgTypes,
+		GoTypes:           file_proto_ember_v1_semantic_cache_proto_goTypes,
+		DependencyIndexes: file_proto_ember_v1_semantic_cache_proto_depIdxs,
+		MessageInfos:      file_proto_ember_v1_semantic_cache_proto_msgTypes,
 	}.Build()
-	File_internal_server_semantic_cache_proto = out.File
-	file_internal_server_semantic_cache_proto_goTypes = nil
-	file_internal_server_semantic_cache_proto_depIdxs = nil
+	File_proto_ember_v1_semantic_cache_proto = out.File
+	file_proto_ember_v1_semantic_cache_proto_goTypes = nil
+	file_proto_ember_v1_semantic_cache_proto_depIdxs = nil
 }

--- a/proto/ember/v1/semantic_cache.proto
+++ b/proto/ember/v1/semantic_cache.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ember.v1;
 
-option go_package = "github.com/EricNguyen1206/erion-ember/internal/server;server";
+option go_package = "github.com/EricNguyen1206/erion-ember/proto/ember/v1;emberv1";
 
 service SemanticCacheService {
   rpc Get(GetRequest) returns (GetResponse);

--- a/proto/ember/v1/semantic_cache_grpc.pb.go
+++ b/proto/ember/v1/semantic_cache_grpc.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v5.28.3
-// source: internal/server/semantic_cache.proto
+// source: proto/ember/v1/semantic_cache.proto
 
-package server
+package emberv1
 
 import (
 	context "context"
@@ -267,5 +267,5 @@ var SemanticCacheService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "internal/server/semantic_cache.proto",
+	Metadata: "proto/ember/v1/semantic_cache.proto",
 }


### PR DESCRIPTION
## Summary
- harden the self-hosted release 1 server with readiness checks, safer HTTP request handling, basic metrics, quieter request logging, and stronger CI/release validation
- publish the release gRPC contract under `proto/ember/v1`, wire the server to that public proto surface, and add integration coverage for the public proto client
- add raw Go and Node.js integration examples plus a runnable showcase demo so users can validate the miss -> set -> hit flow without an SDK

## Release 1 Scope
- self-hosted
- single-node
- memory-only
- gRPC preferred, HTTP supported
- exact-match first, lexical BM25 + Jaccard fallback
- no persistence, clustering, or SDKs in this release

## Validation
- `go build -o bin/erion-ember ./cmd/server/`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run ./...`

## Notes
- HTTP JSON request bodies are capped at 8 MiB; larger backend payloads should use gRPC
- the public gRPC contract now lives at `proto/ember/v1/semantic_cache.proto`
- release examples now cover:
  - Go gRPC
  - Go HTTP
  - Node.js gRPC
  - Node.js HTTP
  - showcase demo with stats and metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 1: Memory-Only Semantic Cache for Chat Backends

* **New Features**
  * Memory-only semantic cache with exact-match-first retrieval followed by lexical fallback (BM25 + Jaccard).
  * Non-root container execution and configurable HTTP/gRPC ports.
  * Readiness (`/ready`) and metrics (`/metrics`) HTTP endpoints; cache statistics reporting.
  * Support for TTL-based eviction and configurable similarity thresholds.

* **Documentation**
  * Complete API reference, user guide, and architecture documentation for Release 1.
  * Go and Node.js examples for gRPC and HTTP integration.
  * Showcase demo with Docker Compose for quick evaluation.

* **Chores**
  * CI/CD validation workflow and release checklist automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->